### PR TITLE
feat: add basic validations to the crd

### DIFF
--- a/manifests/kombiner.x-k8s.io_placementrequests.yaml
+++ b/manifests/kombiner.x-k8s.io_placementrequests.yaml
@@ -56,26 +56,34 @@ spec:
                     scheduled. The bind is scoped to the PlacementRequest namespace.
                   properties:
                     nodeName:
+                      description: NodeName is the name of the node where the pod
+                        should be scheduled.
+                      minLength: 1
                       type: string
                     podName:
+                      description: PodName is the name of the pod that should be bound
+                        to the node.
+                      minLength: 1
                       type: string
                     podUID:
-                      description: |-
-                        UID is a type that holds unique ID values, including UUIDs.  Because we
-                        don't ONLY use UUIDs, this is an alias to string.  Being a type captures
-                        intent and helps make sure that UIDs and names do not get conflated.
+                      description: PodUID is the UID of the pod that should be bound
+                        to the node.
                       type: string
                   required:
                   - nodeName
                   - podName
                   - podUID
                   type: object
+                minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
               policy:
                 description: |-
                   Policy indicates the relationship between the bindings in a
                   placement request.
+                enum:
+                - Lenient
+                - AllOrNothing
                 type: string
               priority:
                 description: |-
@@ -87,11 +95,13 @@ spec:
                   SchedulerName is the name of the scheduler that is responsible for
                   creating this placement request. This is used to identify the
                   queue that the placement request belongs to.
+                minLength: 1
                 type: string
             required:
             - bindings
             - policy
             - priority
+            - schedulerName
             type: object
           status:
             description: |-
@@ -117,14 +127,18 @@ spec:
                         scheduled. The bind is scoped to the PlacementRequest namespace.
                       properties:
                         nodeName:
+                          description: NodeName is the name of the node where the
+                            pod should be scheduled.
+                          minLength: 1
                           type: string
                         podName:
+                          description: PodName is the name of the pod that should
+                            be bound to the node.
+                          minLength: 1
                           type: string
                         podUID:
-                          description: |-
-                            UID is a type that holds unique ID values, including UUIDs.  Because we
-                            don't ONLY use UUIDs, this is an alias to string.  Being a type captures
-                            intent and helps make sure that UIDs and names do not get conflated.
+                          description: PodUID is the UID of the pod that should be
+                            bound to the node.
                           type: string
                       required:
                       - nodeName

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -68,15 +68,20 @@ type PlacementRequestResult string
 type PlacementRequestSpec struct {
 	// Policy indicates the relationship between the bindings in a
 	// placement request.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=Lenient;AllOrNothing
 	Policy PlacementRequestPolicy `json:"policy" protobuf:"bytes,1,opt,name=policy,casttype=PlacementRequestPolicy"`
 
 	// Priority is an arbitrary integer, placement requests with a higher
 	// priority are served first when processing the scheduler queue.
+	// +kubebuilder:validation:Required
 	Priority PlacementRequestPriority `json:"priority" protobuf:"varint,2,opt,name=priority,casttype=PlacementRequestPriority"`
 
 	// SchedulerName is the name of the scheduler that is responsible for
 	// creating this placement request. This is used to identify the
 	// queue that the placement request belongs to.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	SchedulerName string `json:"schedulerName,omitempty" protobuf:"bytes,3,opt,name=schedulerName"`
 
 	// Bingings is a list of bindings that the scheduler wants to have
@@ -85,6 +90,8 @@ type PlacementRequestSpec struct {
 	// the node.
 	//
 	// +listType=atomic
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinItems=1
 	Bindings []Binding `json:"bindings" protobuf:"bytes,4,rep,name=bindings"`
 }
 
@@ -92,9 +99,19 @@ type PlacementRequestSpec struct {
 // the pod name, pod UID and the node name where the pod should be
 // scheduled. The bind is scoped to the PlacementRequest namespace.
 type Binding struct {
-	PodName  string    `json:"podName" protobuf:"bytes,1,opt,name=podName"`
-	PodUID   types.UID `json:"podUID" protobuf:"bytes,2,opt,name=podUID"`
-	NodeName string    `json:"nodeName" protobuf:"bytes,2,opt,name=nodeName"`
+	// PodName is the name of the pod that should be bound to the node.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	PodName string `json:"podName" protobuf:"bytes,1,opt,name=podName"`
+
+	// PodUID is the UID of the pod that should be bound to the node.
+	// +kubebuilder:validation:Required
+	PodUID types.UID `json:"podUID" protobuf:"bytes,2,opt,name=podUID"`
+
+	// NodeName is the name of the node where the pod should be scheduled.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	NodeName string `json:"nodeName" protobuf:"bytes,3,opt,name=nodeName"`
 }
 
 // PlacementRequestStatus holds the status for a PlacementRequest, it contains


### PR DESCRIPTION
- policy must be one of the valid values.
- bindings can't be empty.
- scheduler name must be provided.