### PR TITLE
feat(bind): retrieve the scheduler name from the pod's spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module kombiner
 go 1.24.5
 
 require (
+	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.10.0
 	k8s.io/api v0.33.3
 	k8s.io/apimachinery v0.33.3
@@ -41,7 +42,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.23.2 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0 // indirect

--- a/pkg/scheduler/bind-plugin.go
+++ b/pkg/scheduler/bind-plugin.go
@@ -41,6 +41,14 @@ func (p *BindPlugin) Bind(
 ) *framework.Status {
 	// we will use the pod uid as the placement request name.
 	prname := string(pod.UID)
+	if prname == "" {
+		return framework.AsStatus(fmt.Errorf("pod %v/%v is missing its UID", pod.Namespace, pod.Name))
+	}
+
+	schedulerName := pod.Spec.SchedulerName
+	if schedulerName == "" {
+		schedulerName = corev1.DefaultSchedulerName
+	}
 
 	pr := &v1alpha1.PlacementRequest{
 		ObjectMeta: metav1.ObjectMeta{
@@ -58,7 +66,7 @@ func (p *BindPlugin) Bind(
 		Spec: v1alpha1.PlacementRequestSpec{
 			Policy:        v1alpha1.PlacementRequestPolicyLenient,
 			Priority:      0,
-			SchedulerName: SchedulerName,
+			SchedulerName: schedulerName,
 			Bindings: []v1alpha1.Binding{
 				{
 					PodName:  pod.Name,

--- a/pkg/scheduler/bind_plugin_test.go
+++ b/pkg/scheduler/bind_plugin_test.go
@@ -1,0 +1,110 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2/ktesting"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+
+  "kombiner/pkg/apis/v1alpha1"
+	"kombiner/pkg/generated/clientset/versioned/fake"
+)
+
+func TestBindPluginSchedulerNameSet(t *testing.T) {
+	tests := []struct {
+		name                  string
+		podUID                types.UID
+		schedulerName         string
+		expectedSchedulerName string
+		skipPRPulling         bool
+		injectErr             error
+	}{
+		{
+			name:                  "default scheduler",
+			podUID:                "8d9f8c5e-13a3-4b7d-8d7e-4c23b19c1f74",
+			expectedSchedulerName: corev1.DefaultSchedulerName,
+		},
+		{
+			name:                  "custom scheduler",
+			podUID:                "8d9f8c5e-13a3-4b7d-8d7e-4c23b19c1f74",
+			schedulerName:         "custom-scheduler",
+			expectedSchedulerName: "custom-scheduler",
+		},
+		{
+			name:                  "no pod uid",
+			schedulerName:         "custom-scheduler",
+			expectedSchedulerName: "custom-scheduler",
+			skipPRPulling:         true,
+			injectErr:             fmt.Errorf("pod ns/foo is missing its UID"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			client := fake.NewSimpleClientset()
+
+			testPod := st.MakePod().Name("foo").Namespace("ns").Obj()
+			testPod.UID = tt.podUID
+			testPod.Spec.SchedulerName = tt.schedulerName
+
+			var bindStatus *framework.Status
+			bindDoneChan := make(chan struct{})
+			// run the binding step in parallel so the created PR can be inspected and updated
+			go func() {
+				binder := &BindPlugin{client: client}
+				bindStatus = binder.Bind(ctx, nil, testPod, "testNode")
+				bindDoneChan <- struct{}{}
+			}()
+
+			if !tt.skipPRPulling {
+				prClient := client.KombinerV1alpha1().PlacementRequests(testPod.Namespace)
+				if err := wait.PollUntilContextTimeout(
+					ctx, 50*time.Millisecond, time.Second, true,
+					func(ctx context.Context) (bool, error) {
+						pr, err := prClient.Get(ctx, string(testPod.UID), metav1.GetOptions{})
+						if err != nil {
+							if errors.IsNotFound(err) {
+								return false, nil
+							}
+							return false, err
+						}
+						pr.Status = v1alpha1.PlacementRequestStatus{
+							Result: v1alpha1.PlacementRequestResultSuccess,
+						}
+						_, err = prClient.Update(ctx, pr, metav1.UpdateOptions{})
+						if err != nil {
+							return false, err
+						}
+
+						if diff := cmp.Diff(tt.expectedSchedulerName, pr.Spec.SchedulerName); diff != "" {
+							t.Errorf("got different schedulerName (-want, +got): %s", diff)
+						}
+
+						return true, nil
+					},
+				); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			<-bindDoneChan
+			if got := bindStatus.AsError(); (tt.injectErr != nil) != (got != nil) {
+				t.Errorf("got error %q, want %q", got, tt.injectErr)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/defaults.go
+++ b/pkg/scheduler/defaults.go
@@ -1,11 +1,6 @@
 package scheduler
 
 const (
-	// SchedulerName is the name of the scheduler as deployed in the
-	// cluster. This scheduler operates only on pods who specify the
-	// right schedulerName property.
-	SchedulerName = "kombiner-scheduler"
-
 	// PluginName is the name of the plugin as used in the scheduler
 	// configuration file.
 	PluginName = "PlacementRequestBinder"


### PR DESCRIPTION
Each profile (framework instance) configures its event handlers to filter and process only Pods whose `.spec.schedulerName` matches the scheduler name associated with that profile. Consequently, every Pod received at the `Bind` extension point is expected to have its `.spec.schedulerName` field set to the scheduler’s name for that profile.

Fixes: https://github.com/ricardomaraschini/kombiner/issues/26