### PR TITLE
ci: implement conventional commit check

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -16,6 +16,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Conventional commit
+      uses: ytanikin/pr-conventional-commits@1.4.2
+      with:
+        task_types: '["ci","feat","fix","docs","test","chore","revert"]'
+        add_label: false
+
     - name: Setup go
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
verifies that the pr title matches the conventional commit.