### PR TITLE
ci: disable conventional commit check on main

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -18,6 +18,7 @@ jobs:
 
     - name: Conventional commit
       uses: ytanikin/pr-conventional-commits@1.4.2
+      if: github.ref != 'refs/heads/main'
       with:
         task_types: '["ci","feat","fix","docs","test","chore","revert"]'
         add_label: false


### PR DESCRIPTION
this check isn't supposed to run upon merge. this is a pr specific step.