### PR TITLE
feat!: add new fairness algorithm implementation

### DIFF
--- a/helm/templates/controller-config.yaml
+++ b/helm/templates/controller-config.yaml
@@ -8,6 +8,8 @@ data:
   config.yaml: |-
     apiVersion: config.kombiner.x-k8s.io/v1alpha1
     kind: Configuration
+    # supported algoriths: RoundRobin and Uniform
+    # fairnessAlgorithm: RoundRobin
     queues:
     - schedulerName: kombiner-scheduler
       weight: 50

--- a/helm/templates/controller-config.yaml
+++ b/helm/templates/controller-config.yaml
@@ -8,7 +8,7 @@ data:
   config.yaml: |-
     apiVersion: config.kombiner.x-k8s.io/v1alpha1
     kind: Configuration
-    # supported algoriths: RoundRobin and Uniform
+    # supported algorithms: RoundRobin and Uniform
     # fairnessAlgorithm: RoundRobin
     queues:
     - schedulerName: kombiner-scheduler

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -23,6 +23,20 @@ import (
 // +k8s:defaulter-gen=true
 // +kubebuilder:object:root=true
 
+type FairnessAlgorithm string
+
+const (
+	// RoundRobin is the default algorithm that processes placement requests
+	// in a round-robin fashion. It ensures that each scheduler gets a chance
+	// to process its placement requests in a fair manner.
+	RoundRobin FairnessAlgorithm = "RoundRobin"
+
+	// Uniform is an algorithm that processes placement requests in a uniform
+	// manner. It uses a weighted random selection algorithm to determine the
+	// next placement request to process.
+	Uniform FairnessAlgorithm = "Uniform"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // Configuration is the Schema for the kombinerconfigurations API
 type Configuration struct {
@@ -30,6 +44,13 @@ type Configuration struct {
 
 	// Queues provides configuration for individual queues
 	Queues []Queue `json:"queues"`
+
+	// FairnessAlgorithm defines the algorithm used by the kombiner
+	// controller when selecting the next PlacementRequest to process.
+	// Fairness is controlled by this field. The default value, if not
+	// specified, is RoundRobin.
+	// +kubebuilder:validation:Enum=RoundRobin;Uniform
+	FairnessAlgorithm FairnessAlgorithm `json:"fairnessAlgorithm,omitempty"`
 
 	// Plugins captures a configuration for cluster wide validation
 	// +optional

--- a/pkg/queue/config.go
+++ b/pkg/queue/config.go
@@ -1,0 +1,86 @@
+package queue
+
+import (
+	"fmt"
+
+	"kombiner/pkg/apis/config/v1alpha1"
+)
+
+// QueueConfig defines the configuration for a queue in the queue iterator. It
+// includes the name of the queue, its weight, and the actual queue. The Weight
+// determines how often the queue will be processed in each iteration and it is
+// proportional to the sum of all weights provided for the QueueIterator.
+type QueueConfig struct {
+	Name   string
+	Weight uint
+	Queue  *PlacementRequestQueue
+}
+
+// Validate checks the QueueConfig for correctness. We ensure that the queue
+// has a name, its weight is greater than zero and that we have a valid pointer
+// to a PlacementRequestQueue.
+func (c *QueueConfig) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("queue name cannot be empty")
+	}
+	if c.Queue == nil {
+		return fmt.Errorf("queue reference cannot be nil")
+	}
+	return nil
+}
+
+// QueueConfigs is a list of QueueConfig objects. This struct is useful for
+// batch operations over multiple queues.
+type QueueConfigs []QueueConfig
+
+// ToMap converts the QueueConfigs to a map where the key is the queue name
+// and the value is the PlacementRequestQueue. Multiple QueueConfigs for the
+// same queue name will overwrite each other.
+func (c QueueConfigs) ToMap() map[string]*PlacementRequestQueue {
+	m := make(map[string]*PlacementRequestQueue, len(c))
+	for _, cfg := range c {
+		m[cfg.Name] = cfg.Queue
+	}
+	return m
+}
+
+// AddPushHandlers adds the same push handler to all queues within a queue
+// configs slice.
+func (c *QueueConfigs) AddPushHandler(handler func()) {
+	for _, config := range *c {
+		config.Queue.AddPushHandler(handler)
+	}
+}
+
+// Validate checks the QueueConfigs for correctness. We ensure that each queue
+// has the mandatory fields and that they all have different names.
+func (c QueueConfigs) Validate() error {
+	seen := map[string]bool{}
+	for _, cfg := range c {
+		if _, ok := seen[cfg.Name]; ok {
+			return fmt.Errorf("duplicate config for queue %q", cfg.Name)
+		}
+		seen[cfg.Name] = true
+		if err := cfg.Validate(); err != nil {
+			return fmt.Errorf("queue %q: %w", cfg.Name, err)
+		}
+	}
+	return nil
+}
+
+// QueueConfigFromV1Alpha1Config parses the controller configuration directly
+// into a QueueConfigs object. No validation is performed at this stage.
+func QueueConfigFromV1Alpha1Config(raw v1alpha1.Configuration) QueueConfigs {
+	configs := QueueConfigs{}
+	for _, config := range raw.Queues {
+		configs = append(
+			configs,
+			QueueConfig{
+				Name:   config.SchedulerName,
+				Weight: config.Weight,
+				Queue:  NewPlacementRequestQueue(),
+			},
+		)
+	}
+	return configs
+}

--- a/pkg/queue/config.go
+++ b/pkg/queue/config.go
@@ -26,6 +26,9 @@ func (c *QueueConfig) Validate() error {
 	if c.Queue == nil {
 		return fmt.Errorf("queue reference cannot be nil")
 	}
+	if c.Weight == 0 {
+		return fmt.Errorf("queue weight must be greater than zero")
+	}
 	return nil
 }
 

--- a/pkg/queue/iterator-options.go
+++ b/pkg/queue/iterator-options.go
@@ -1,0 +1,14 @@
+package queue
+
+// QueueIteratorOption is a function that modifies the QueueIterator
+// configuration. It can be used to set various options for the iterator.
+type QueueIteratorOption func(*QueueIterator)
+
+// WithReaderFactor is needed for allowing the users to change the algorithm
+// used to read messages from the iterator internal queues. The goal is to
+// allow flexibility.
+func WithReaderFactory(factory ReaderFactory) QueueIteratorOption {
+	return func(q *QueueIterator) {
+		q.readerFactory = factory
+	}
+}

--- a/pkg/queue/iterator-options.go
+++ b/pkg/queue/iterator-options.go
@@ -4,7 +4,7 @@ package queue
 // configuration. It can be used to set various options for the iterator.
 type QueueIteratorOption func(*QueueIterator)
 
-// WithReaderFactor is needed for allowing the users to change the algorithm
+// WithReaderFactory is needed for allowing the users to change the algorithm
 // used to read messages from the iterator internal queues. The goal is to
 // allow flexibility.
 func WithReaderFactory(factory ReaderFactory) QueueIteratorOption {

--- a/pkg/queue/iterator.go
+++ b/pkg/queue/iterator.go
@@ -3,9 +3,6 @@ package queue
 import (
 	"context"
 	"fmt"
-	"math/rand"
-	"slices"
-	"sync"
 
 	"kombiner/pkg/apis/kombiner/v1alpha1"
 )
@@ -13,10 +10,10 @@ import (
 // QueueIterator is an entity that iterates over multiple queues popping
 // PlacementRequests from them respecting their Weight.
 type QueueIterator struct {
-	Next    chan *v1alpha1.PlacementRequest
-	mtx     sync.Mutex
-	configs QueueConfigs
-	resume  chan bool
+	Next          chan *v1alpha1.PlacementRequest
+	readerFactory ReaderFactory
+	configs       QueueConfigs
+	resume        chan bool
 }
 
 // Resume ensures we have a resume signal ready to be intercepted by the Run()
@@ -47,92 +44,46 @@ func (q *QueueIterator) Run(ctx context.Context) {
 		default:
 		}
 
-		var cfgs []QueueConfig
+		configs := QueueConfigs{}
+		configs = append(configs, q.configs...)
 
-		q.mtx.Lock()
-		cfgs = append(cfgs, q.configs...)
-		q.mtx.Unlock()
-
-		allempty, nrconfigs := true, len(cfgs)
-		for range nrconfigs {
-			if i, end := q.readOne(ctx, cfgs); !end {
-				cfgs = slices.Delete(cfgs, i, i+1)
-				continue
-			}
-
-			allempty = false
-			break
-		}
-
-		if allempty {
+		reader := q.readerFactory(configs)
+		for p := reader.Read(ctx); p != nil; p = reader.Read(ctx) {
 			select {
 			case <-ctx.Done():
-			case <-q.resume:
+			case q.Next <- p:
 			}
 		}
-	}
-}
 
-// readOne reads a single PlacementRequest from the queues based on their
-// weights. It selects the next queue to process and attempts to pop a
-// PlacementRequest from it. If a request is found this function returns
-// true, otherwise it returns false. The index of the selected queue is
-// also returned. If a message is found it is written to the Next channel
-// so this function may block.
-func (q *QueueIterator) readOne(ctx context.Context, configs []QueueConfig) (int, bool) {
-	index := q.selectNextQueue(configs)
-	if pr := configs[index].Queue.Pop(); pr != nil {
+		// nothing found to read in the queues, we now need to wait for
+		// the resume signal so we can resume reading.
 		select {
 		case <-ctx.Done():
-		case q.Next <- pr:
-		}
-		return index, true
-	}
-	return index, false
-}
-
-// selectNextQueue uses the weights to select the next queue to process. It
-// returns the index of the selected queue based on the weights provided in
-// the QueueConfig. The selection is done in a weighted random manner.
-func (q *QueueIterator) selectNextQueue(configs []QueueConfig) int {
-	var total uint
-	for _, config := range configs {
-		total += config.Weight
-	}
-
-	// select a random number between 1 and total + 1. this random number
-	// will fit somewhere in the sum of all individual weights.
-	selected := uint(rand.Intn(int(total)) + 1)
-
-	// we keep summing the weights until we find the sum to be greater than
-	// or equal to the selected number. this means that the queue at that
-	// index is the one we should process next.
-	var sum uint
-	for i, config := range configs {
-		if sum += config.Weight; selected <= sum {
-			return i
+		case <-q.resume:
 		}
 	}
-
-	// this should never happen as we always select a number between 1 and
-	// total + 1, which is the sum of all weights.
-	panic("no queue selected, this should never happen")
 }
 
 // NewQueueIterator creates a queue iterator based on the provided QueueConfig
 // objects. This function registers a custom push handler for each queue so it
 // is capable of resuming reading from queues.
-func NewQueueIterator(configs QueueConfigs) (*QueueIterator, error) {
+func NewQueueIterator(configs QueueConfigs, opts ...QueueIteratorOption) (*QueueIterator, error) {
 	if err := configs.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid queue configuration: %w", err)
 	}
 
 	it := &QueueIterator{
-		Next:    make(chan *v1alpha1.PlacementRequest),
-		resume:  make(chan bool, 2),
-		configs: configs,
+		Next:          make(chan *v1alpha1.PlacementRequest),
+		readerFactory: NewUniformReader,
+		resume:        make(chan bool, 2),
+		configs:       configs,
 	}
 
 	configs.AddPushHandler(it.Resume)
+
+	for _, opt := range opts {
+		opt(it)
+	}
+
 	return it, nil
 }

--- a/pkg/queue/iterator_test.go
+++ b/pkg/queue/iterator_test.go
@@ -164,54 +164,6 @@ func TestQueueIteratorReadBeforeWrite(t *testing.T) {
 	}
 }
 
-func TestQueueIterator_nextQueue(t *testing.T) {
-	assert := assert.New(t)
-
-	configs := []QueueConfig{
-		{
-			Name:   "scheduler-1",
-			Weight: 7,
-			Queue:  NewPlacementRequestQueue(),
-		},
-		{
-			Name:   "scheduler-2",
-			Weight: 2,
-			Queue:  NewPlacementRequestQueue(),
-		},
-		{
-			Name:   "scheduler-3",
-			Weight: 1,
-			Queue:  NewPlacementRequestQueue(),
-		},
-	}
-
-	var iterator QueueIterator
-
-	counters := map[string]int{}
-	iteractions := 10000000
-	for range iteractions {
-		next := iterator.selectNextQueue(configs)
-		counters[configs[next].Name]++
-	}
-
-	percentage := map[string]int{}
-	for name, c := range counters {
-		percentage[name] = int(float64(c) / float64(iteractions) * 100)
-	}
-
-	// ballpark here, we expect the first queue to be selected 70% of the time,
-	// the second queue 20% of the time and the third queue 10% of the time. we
-	// give them a 2% margin of error.
-	assert.GreaterOrEqual(percentage["scheduler-1"], 68, "scheduler-1 should be selected at least 68% of the time")
-	assert.LessOrEqual(percentage["scheduler-1"], 72, "scheduler-1 should be selected at most 72% of the time")
-
-	assert.GreaterOrEqual(percentage["scheduler-2"], 18, "scheduler-2 should be selected at least 18% of the time")
-	assert.LessOrEqual(percentage["scheduler-2"], 22, "scheduler-2 should be selected at most 22% of the time")
-
-	assert.GreaterOrEqual(percentage["scheduler-3"], 8, "scheduler-3 should be selected at least 8% of the time")
-	assert.LessOrEqual(percentage["scheduler-3"], 12, "scheduler-3 should be selected at most 12% of the time")
-}
-
 func TestQueueIteratorMultipleConcurrent(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/queue/placement-request.go
+++ b/pkg/queue/placement-request.go
@@ -71,6 +71,13 @@ func (q *PlacementRequestQueue) AddPushHandler(handler func()) {
 	q.pushHandlers = append(q.pushHandlers, handler)
 }
 
+// Len returns the number of PlacementRequests awaiting in the inner queue.
+func (q *PlacementRequestQueue) Len() int {
+	q.mtx.Lock()
+	defer q.mtx.Unlock()
+	return q.queue.Len()
+}
+
 // NewPlacementRequestQueue creates a new PlacementRequestQueue.
 func NewPlacementRequestQueue() *PlacementRequestQueue {
 	return &PlacementRequestQueue{

--- a/pkg/queue/reader.go
+++ b/pkg/queue/reader.go
@@ -1,0 +1,19 @@
+package queue
+
+import (
+	"context"
+	"kombiner/pkg/apis/kombiner/v1alpha1"
+)
+
+// Reader function is used to abstract the multiple queue readers we have
+// implemented. The role of a reader is to determine the order in which
+// messages should be read from the provided queues and return the next
+// PlacementRequest to be processed. The readers are expected to return
+// nil if there is nothing else to be read in a given moment.
+type Reader interface {
+	Read(context.Context) *v1alpha1.PlacementRequest
+}
+
+// ReaderFactory is a funtion that return a queue reader for a list of
+// provided queues.
+type ReaderFactory func(QueueConfigs) Reader

--- a/pkg/queue/round-robin.go
+++ b/pkg/queue/round-robin.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 )
 
-// MininumBindings is the very minimum binds we will ensure to the queue with
+// MinimumBindings is the very minimum binds we will ensure to the queue with
 // the least weight. Each bind in a PlacementRequest is counted towards this
 // amount.
 const MinimumBindings = 10
@@ -28,11 +28,11 @@ type RoundRobinReader struct {
 // Read keeps reading from the same queue until it is empty or we reached the
 // max of bindings defined per queue. The maximum number of bindings is
 // relative to the weight of reach queue. The queue with the lowest weight
-// receives MininumBindings.
+// receives MinimumBindings.
 func (r *RoundRobinReader) Read(ctx context.Context) *v1alpha1.PlacementRequest {
 	// if the queues are empty at this stage we return nil as there is
 	// nothing else to read. this is also our stop condition for the
-	// recursiver calls.
+	// recursive calls.
 	if r.empty() {
 		return nil
 	}
@@ -80,7 +80,7 @@ func (r *RoundRobinReader) reset() {
 	}
 }
 
-// next function is to retur the next queue from where we should read. this
+// next function is to return the next queue from where we should read. this
 // function iterates over the configs and finds one for which we haven't yet
 // exhausted the maximum number of bindings. If all queues are exhausted
 // it returns -1.

--- a/pkg/queue/round-robin.go
+++ b/pkg/queue/round-robin.go
@@ -1,0 +1,132 @@
+package queue
+
+import (
+	"context"
+	"kombiner/pkg/apis/kombiner/v1alpha1"
+	"math"
+	"slices"
+)
+
+// MininumBindings is the very minimum binds we will ensure to the queue with
+// the least weight. Each bind in a PlacementRequest is counted towards this
+// amount.
+const MinimumBindings = 10
+
+// ExtendedQueueConfig extends a QueueConfig to also contain a property holding
+// how many binds are allowed for a queue and a counter for how many binds were
+// already read.
+type ExtendedQueueConfig struct {
+	QueueConfig
+	MaximumBindings int
+	BindingsRead    int
+}
+
+type RoundRobinReader struct {
+	configs []ExtendedQueueConfig
+}
+
+// Read keeps reading from the same queue until it is empty or we reached the
+// max of bindings defined per queue. The maximum number of bindings is
+// relative to the weight of reach queue. The queue with the lowest weight
+// receives MininumBindings.
+func (r *RoundRobinReader) Read(ctx context.Context) *v1alpha1.PlacementRequest {
+	// if the queues are empty at this stage we return nil as there is
+	// nothing else to read. this is also our stop condition for the
+	// recursiver calls.
+	if r.empty() {
+		return nil
+	}
+
+	var index int
+	if index = r.next(); index < 0 {
+		// if we can't find a queue from which to read and we know they
+		// aren't empty then we can reset and start over.
+		r.reset()
+		if index = r.next(); index < 0 {
+			// this should never happen
+			panic("no queues to read from but not all are empty")
+		}
+	}
+
+	if pr := r.configs[index].Queue.Pop(); pr != nil {
+		r.configs[index].BindingsRead += len(pr.Spec.Bindings)
+		return pr
+	}
+
+	// we haven't found nothing to read on this queue so we aren't supposed
+	// to keep waiting. we set the BindingsRead for the queue to the max to
+	// indicate we don't want to read from it anymore and then call this
+	// function recursively to try the next queue.
+	r.configs[index].BindingsRead = r.configs[index].MaximumBindings
+	return r.Read(ctx)
+}
+
+// empty returns true if all queues are empty.
+func (r *RoundRobinReader) empty() bool {
+	for _, cfg := range r.configs {
+		if cfg.Queue.Len() > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// reset resets the BindingsRead counter for all queues. This is useful when we
+// want to start reading from the beginning again.
+func (r *RoundRobinReader) reset() {
+	for i, cfg := range r.configs {
+		cfg.BindingsRead = 0
+		r.configs[i] = cfg
+	}
+}
+
+// next function is to retur the next queue from where we should read. this
+// function iterates over the configs and finds one for which we haven't yet
+// exhausted the maximum number of bindings. If all queues are exhausted
+// it returns -1.
+func (r *RoundRobinReader) next() int {
+	for i, cfg := range r.configs {
+		if cfg.BindingsRead < cfg.MaximumBindings {
+			return i
+		}
+	}
+	return -1
+}
+
+// NewRoundRobinReader creates a new RoundRobinReader with the provided queue
+// configurations. Each queue configuration is extended with a default maximum
+// number of bindings, which must be equal or greater than MinimumBindings.
+// The lighter queue configuration receives MinimumBindings and the rest are
+// calculated based on the weight of each queue relative to the lightest one.
+// This function expects the configuration to be properly sanitized before
+// entering here, it bravely runs away with a panic with invalid data.
+func NewRoundRobinReader(configs QueueConfigs) Reader {
+	lighter := slices.MinFunc(
+		configs,
+		func(a, b QueueConfig) int {
+			return int(a.Weight) - int(b.Weight)
+		},
+	)
+
+	// this is a sanity check, we can't have queues with zeroed out
+	// weights as this makes no sense in the context. We are dividing
+	// by the lowest weight but as we convert it to a float to do so
+	// we end up obtaining a +Inf value, and that is no bueno.
+	if lighter.Weight == 0 {
+		panic("queue with zero weight provided")
+	}
+
+	extended := make([]ExtendedQueueConfig, len(configs))
+	for i, cfg := range configs {
+		multiplier := float64(cfg.Weight) / float64(lighter.Weight)
+		maxbindings := math.Ceil(multiplier * float64(MinimumBindings))
+		extended[i] = ExtendedQueueConfig{
+			QueueConfig:     cfg,
+			MaximumBindings: int(maxbindings),
+		}
+	}
+
+	return &RoundRobinReader{
+		configs: extended,
+	}
+}

--- a/pkg/queue/round-robin.go
+++ b/pkg/queue/round-robin.go
@@ -27,7 +27,7 @@ type RoundRobinReader struct {
 
 // Read keeps reading from the same queue until it is empty or we reached the
 // max of bindings defined per queue. The maximum number of bindings is
-// relative to the weight of reach queue. The queue with the lowest weight
+// relative to the weight of each queue. The queue with the lowest weight
 // receives MinimumBindings.
 func (r *RoundRobinReader) Read(ctx context.Context) *v1alpha1.PlacementRequest {
 	// if the queues are empty at this stage we return nil as there is

--- a/pkg/queue/round-robin_test.go
+++ b/pkg/queue/round-robin_test.go
@@ -1,0 +1,501 @@
+package queue
+
+import (
+	"context"
+	"kombiner/pkg/apis/kombiner/v1alpha1"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundRobinReader_Read(t *testing.T) {
+	require := require.New(t)
+	for _, tt := range []struct {
+		name    string
+		configs []ExtendedQueueConfig
+		prs     [][]v1alpha1.PlacementRequest
+		want    []v1alpha1.PlacementRequest
+	}{
+		{
+			name: "first queue empty",
+			configs: []ExtendedQueueConfig{
+				{
+					MaximumBindings: 2,
+					BindingsRead:    0,
+					QueueConfig: QueueConfig{
+						Name:  "A",
+						Queue: NewPlacementRequestQueue(),
+					},
+				},
+				{
+					MaximumBindings: 2,
+					BindingsRead:    0,
+					QueueConfig: QueueConfig{
+						Name:  "B",
+						Queue: NewPlacementRequestQueue(),
+					},
+				},
+			},
+			prs: [][]v1alpha1.PlacementRequest{
+				{},
+				{
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod3"},
+							},
+						},
+					},
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod4"},
+							},
+						},
+					},
+				},
+			},
+			want: []v1alpha1.PlacementRequest{
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod3"},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod4"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "all empty",
+			configs: []ExtendedQueueConfig{
+				{
+					MaximumBindings: 2,
+					BindingsRead:    0,
+					QueueConfig: QueueConfig{
+						Name:  "A",
+						Queue: NewPlacementRequestQueue(),
+					},
+				},
+				{
+					MaximumBindings: 2,
+					BindingsRead:    0,
+					QueueConfig: QueueConfig{
+						Name:  "B",
+						Queue: NewPlacementRequestQueue(),
+					},
+				},
+			},
+			prs:  [][]v1alpha1.PlacementRequest{},
+			want: []v1alpha1.PlacementRequest{},
+		},
+		{
+			name: "return all placement requests",
+			configs: []ExtendedQueueConfig{
+				{
+					MaximumBindings: 2,
+					BindingsRead:    0,
+					QueueConfig: QueueConfig{
+						Name:  "A",
+						Queue: NewPlacementRequestQueue(),
+					},
+				},
+				{
+					MaximumBindings: 2,
+					BindingsRead:    0,
+					QueueConfig: QueueConfig{
+						Name:  "B",
+						Queue: NewPlacementRequestQueue(),
+					},
+				},
+			},
+			prs: [][]v1alpha1.PlacementRequest{
+				{
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod1"},
+							},
+						},
+					},
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod2"},
+							},
+						},
+					},
+				},
+				{
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod3"},
+							},
+						},
+					},
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod4"},
+							},
+						},
+					},
+				},
+			},
+			want: []v1alpha1.PlacementRequest{
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod1"},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod2"},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod3"},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod4"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "read max from all queues multiple times",
+			configs: []ExtendedQueueConfig{
+				{
+					MaximumBindings: 1,
+					BindingsRead:    0,
+					QueueConfig: QueueConfig{
+						Name:  "A",
+						Queue: NewPlacementRequestQueue(),
+					},
+				},
+				{
+					MaximumBindings: 1,
+					BindingsRead:    0,
+					QueueConfig: QueueConfig{
+						Name:  "B",
+						Queue: NewPlacementRequestQueue(),
+					},
+				},
+				{
+					MaximumBindings: 1,
+					BindingsRead:    0,
+					QueueConfig: QueueConfig{
+						Name:  "C",
+						Queue: NewPlacementRequestQueue(),
+					},
+				},
+			},
+			prs: [][]v1alpha1.PlacementRequest{
+				{
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod1"},
+							},
+						},
+					},
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod2"},
+							},
+						},
+					},
+				},
+				{
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod3"},
+							},
+						},
+					},
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod4"},
+							},
+						},
+					},
+				},
+				{
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod5"},
+							},
+						},
+					},
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod6"},
+							},
+						},
+					},
+				},
+			},
+			want: []v1alpha1.PlacementRequest{
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod1"},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod3"},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod5"},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod2"},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod4"},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod6"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "start reading from the second queue then reset",
+			configs: []ExtendedQueueConfig{
+				{
+					MaximumBindings: 2,
+					BindingsRead:    2,
+					QueueConfig: QueueConfig{
+						Name:  "A",
+						Queue: NewPlacementRequestQueue(),
+					},
+				},
+				{
+					MaximumBindings: 2,
+					BindingsRead:    0,
+					QueueConfig: QueueConfig{
+						Name:  "B",
+						Queue: NewPlacementRequestQueue(),
+					},
+				},
+			},
+			prs: [][]v1alpha1.PlacementRequest{
+				{
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod1"},
+							},
+						},
+					},
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod2"},
+							},
+						},
+					},
+				},
+				{
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod3"},
+							},
+						},
+					},
+					{
+						Spec: v1alpha1.PlacementRequestSpec{
+							Bindings: []v1alpha1.Binding{
+								{PodName: "pod4"},
+							},
+						},
+					},
+				},
+			},
+			want: []v1alpha1.PlacementRequest{
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod3"},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod4"},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod1"},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.PlacementRequestSpec{
+						Bindings: []v1alpha1.Binding{
+							{PodName: "pod2"},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			for qidx, prs := range tt.prs {
+				for _, pr := range prs {
+					tt.configs[qidx].QueueConfig.Queue.Push(&pr)
+				}
+			}
+
+			ctx := context.Background()
+			rr := &RoundRobinReader{configs: tt.configs}
+			result := []v1alpha1.PlacementRequest{}
+			for pr := rr.Read(ctx); pr != nil; pr = rr.Read(ctx) {
+				result = append(result, *pr)
+			}
+
+			require.Equal(tt.want, result, "should return expected placement requests")
+		})
+	}
+}
+
+func TestRoundRobinReader_next(t *testing.T) {
+	require := require.New(t)
+	for _, tt := range []struct {
+		name    string
+		configs []ExtendedQueueConfig
+		want    int
+	}{
+		{
+			name: "first config not exhausted",
+			configs: []ExtendedQueueConfig{
+				{QueueConfig: QueueConfig{Name: "A"}, MaximumBindings: 2, BindingsRead: 0},
+				{QueueConfig: QueueConfig{Name: "B"}, MaximumBindings: 3, BindingsRead: 1},
+			},
+			want: 0,
+		},
+		{
+			name: "second config available",
+			configs: []ExtendedQueueConfig{
+				{QueueConfig: QueueConfig{Name: "A"}, MaximumBindings: 2, BindingsRead: 2},
+				{QueueConfig: QueueConfig{Name: "B"}, MaximumBindings: 3, BindingsRead: 1},
+			},
+			want: 1,
+		},
+		{
+			name: "overflown first config",
+			configs: []ExtendedQueueConfig{
+				{QueueConfig: QueueConfig{Name: "A"}, MaximumBindings: 2, BindingsRead: 8},
+				{QueueConfig: QueueConfig{Name: "B"}, MaximumBindings: 3, BindingsRead: 1},
+			},
+			want: 1,
+		},
+		{
+			name: "all configs exhausted",
+			configs: []ExtendedQueueConfig{
+				{QueueConfig: QueueConfig{Name: "A"}, MaximumBindings: 1, BindingsRead: 1},
+				{QueueConfig: QueueConfig{Name: "B"}, MaximumBindings: 2, BindingsRead: 2},
+			},
+			want: -1,
+		},
+		{
+			name:    "empty configs",
+			configs: []ExtendedQueueConfig{},
+			want:    -1,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RoundRobinReader{configs: tt.configs}
+			require.Equal(tt.want, r.next(), "next() should return the expected index")
+		})
+	}
+}
+
+func TestNewRoundRobinReader(t *testing.T) {
+	require := require.New(t)
+	configs := QueueConfigs{
+		{Name: "A", Weight: 2},
+		{Name: "B", Weight: 3},
+		{Name: "C", Weight: 4},
+		{Name: "D", Weight: 2},
+		{Name: "E", Weight: 13},
+	}
+
+	reader := NewRoundRobinReader(configs)
+
+	expected := []ExtendedQueueConfig{
+		{
+			QueueConfig:     QueueConfig{Name: "A", Weight: 2},
+			MaximumBindings: MinimumBindings,
+		},
+		{
+			QueueConfig:     QueueConfig{Name: "B", Weight: 3},
+			MaximumBindings: 15,
+		},
+		{
+			QueueConfig:     QueueConfig{Name: "C", Weight: 4},
+			MaximumBindings: 20,
+		},
+		{
+			QueueConfig:     QueueConfig{Name: "D", Weight: 2},
+			MaximumBindings: MinimumBindings,
+		},
+		{
+			QueueConfig:     QueueConfig{Name: "E", Weight: 13},
+			MaximumBindings: 65,
+		},
+	}
+
+	rr, ok := reader.(*RoundRobinReader)
+	require.True(ok, "reader should be of type RoundRobinReader")
+	require.Equal(rr.configs, expected, "expected configs to match")
+}

--- a/pkg/queue/uniform.go
+++ b/pkg/queue/uniform.go
@@ -1,0 +1,76 @@
+package queue
+
+import (
+	"context"
+	"kombiner/pkg/apis/kombiner/v1alpha1"
+	"math/rand"
+	"slices"
+)
+
+// UniformReader is a queue reader that reads messages from multiple queues in
+// a uniform manner based on the weights provided in the QueueConfig. It uses a
+// weighted random selection algorithm to determine the next queue to process.
+// The weights are used to determine the probability of selecting a queue,
+// allowing for a more balanced distribution of messages.
+type UniformReader struct {
+	configs QueueConfigs
+}
+
+// Read is needed in order to select the next message out of a list of queues.
+// This function returns a *v1alpha1.PlacementRequest or nil if there were none
+// to be read (all queues are empty).
+func (u *UniformReader) Read(_ context.Context) *v1alpha1.PlacementRequest {
+	configs := QueueConfigs{}
+	configs = append(configs, u.configs...)
+
+	nrconfigs := len(configs)
+	for range nrconfigs {
+		qidx := u.next(configs)
+		if pr := configs[qidx].Queue.Pop(); pr != nil {
+			return pr
+		}
+
+		// the previus queue returned no message so we can remove it
+		// from the list of queues and try again with the reamining
+		// ones. we keep doing this until no more queues are left.
+		configs = slices.Delete(configs, qidx, qidx+1)
+	}
+	return nil
+}
+
+// next return the next queue from each we should read a message from. This
+// function is always expected to find a next queue or panic if it doesn't as
+// this should never happen.
+func (u *UniformReader) next(configs QueueConfigs) int {
+	var total int
+	for _, config := range configs {
+		total += int(config.Weight)
+	}
+
+	// select a random number between 1 and total + 1. this random number
+	// will fit somewhere in the sum of all individual weights.
+	selected := rand.Intn(total) + 1
+
+	// we keep summing the weights until we find the sum to be greater than
+	// or equal to the selected number. this means that the queue at that
+	// index is the one we should process next.
+	var sum int
+	for i, config := range configs {
+		if sum += int(config.Weight); selected <= sum {
+			return i
+		}
+	}
+
+	// this should never happen as we always select a number between 1 and
+	// total + 1, which is the sum of all weights.
+	panic("no queue selected, this should never happen")
+}
+
+// NewUniformReader creates a new UniformReader with the provided QueueConfig
+// objects. This function is used to initialize the reader with the queues
+// that it should read messages from.
+func NewUniformReader(configs QueueConfigs) Reader {
+	return &UniformReader{
+		configs: configs,
+	}
+}

--- a/pkg/queue/uniform.go
+++ b/pkg/queue/uniform.go
@@ -30,8 +30,8 @@ func (u *UniformReader) Read(_ context.Context) *v1alpha1.PlacementRequest {
 			return pr
 		}
 
-		// the previus queue returned no message so we can remove it
-		// from the list of queues and try again with the reamining
+		// the previous queue returned no message so we can remove it
+		// from the list of queues and try again with the remaining
 		// ones. we keep doing this until no more queues are left.
 		configs = slices.Delete(configs, qidx, qidx+1)
 	}

--- a/pkg/queue/uniform_test.go
+++ b/pkg/queue/uniform_test.go
@@ -1,0 +1,58 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniformReader_next(t *testing.T) {
+	assert := assert.New(t)
+
+	configs := QueueConfigs{
+		{
+			Name:   "scheduler-1",
+			Weight: 7,
+			Queue:  NewPlacementRequestQueue(),
+		},
+		{
+			Name:   "scheduler-2",
+			Weight: 2,
+			Queue:  NewPlacementRequestQueue(),
+		},
+		{
+			Name:   "scheduler-3",
+			Weight: 1,
+			Queue:  NewPlacementRequestQueue(),
+		},
+	}
+
+	reader := NewUniformReader(configs)
+	uniform, ok := reader.(*UniformReader)
+	require.True(t, ok, "reader should be of type UniformReader")
+
+	counters := map[string]int{}
+	iteractions := 10000000
+	for range iteractions {
+		next := uniform.next(configs)
+		counters[configs[next].Name]++
+	}
+
+	percentage := map[string]int{}
+	for name, c := range counters {
+		percentage[name] = int(float64(c) / float64(iteractions) * 100)
+	}
+
+	// ballpark here, we expect the first queue to be selected 70% of the time,
+	// the second queue 20% of the time and the third queue 10% of the time. we
+	// give them a 2% margin of error.
+	assert.GreaterOrEqual(percentage["scheduler-1"], 68, "scheduler-1 should be selected at least 68% of the time")
+	assert.LessOrEqual(percentage["scheduler-1"], 72, "scheduler-1 should be selected at most 72% of the time")
+
+	assert.GreaterOrEqual(percentage["scheduler-2"], 18, "scheduler-2 should be selected at least 18% of the time")
+	assert.LessOrEqual(percentage["scheduler-2"], 22, "scheduler-2 should be selected at most 22% of the time")
+
+	assert.GreaterOrEqual(percentage["scheduler-3"], 8, "scheduler-3 should be selected at least 8% of the time")
+	assert.LessOrEqual(percentage["scheduler-3"], 12, "scheduler-3 should be selected at most 12% of the time")
+}

--- a/pkg/queue/uniform_test.go
+++ b/pkg/queue/uniform_test.go
@@ -33,15 +33,15 @@ func TestUniformReader_next(t *testing.T) {
 	require.True(t, ok, "reader should be of type UniformReader")
 
 	counters := map[string]int{}
-	iteractions := 10000000
-	for range iteractions {
+	iterations := 10000000
+	for range iterations {
 		next := uniform.next(configs)
 		counters[configs[next].Name]++
 	}
 
 	percentage := map[string]int{}
 	for name, c := range counters {
-		percentage[name] = int(float64(c) / float64(iteractions) * 100)
+		percentage[name] = int(float64(c) / float64(iterations) * 100)
 	}
 
 	// ballpark here, we expect the first queue to be selected 70% of the time,


### PR DESCRIPTION
this new fairness algorithm is now the default if no other is chosen by the user. we now have two different algorithms:

#### uniform (optionally enabled, used to be the default)

this one ensures a fairness processing for all schedulers as the time passes. it selects the next queue from where read the placement requests using the queue weights (the higher the weight the higher the chances) . if the selected queue is empty then moves to the next (selecting by the remaining queue weights).

#### round-robin (the new default):

weight determines how many pod bindings are processed for a given queue before moving to the next one in a well known order (the same order they are defined in the configuration). flow moves to the next queue if either we have consumed all pod bindings for the queue (this value is determined by the queue weight) or the queue is empty.